### PR TITLE
Support VLEN=64 tests

### DIFF
--- a/generator/insn_util.go
+++ b/generator/insn_util.go
@@ -66,7 +66,7 @@ func (l LMUL) String() string {
 type VLEN int
 
 func (v VLEN) Valid() bool {
-	return 128 <= v && v <= 4096 && v&(v-1) == 0
+	return 64 <= v && v <= 4096 && v&(v-1) == 0
 }
 
 type XLEN int


### PR DESCRIPTION
There seems to be no reason why VLEN=64 should not be supported... this already seems to work