### PR TITLE
Remove git-submodule-init make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,6 @@ endif
 
 all: compile-stage2
 
-git-submodule-init:
-	git submodule update --init
-
 build: build-generator build-merger
 
 build-generator:
@@ -60,7 +57,7 @@ build-patcher-spike: pspike/pspike.cc
 unittest:
 	go test ./...
 
-generate-stage1: clean-out git-submodule-init build
+generate-stage1: clean-out build
 	@mkdir -p ${OUTPUT_STAGE1}
 	build/generator -VLEN ${VLEN} -XLEN ${XLEN} -split=${SPLIT} -integer=${INTEGER} -stage1output ${OUTPUT_STAGE1} -configs ${CONFIGS}
 
@@ -105,7 +102,6 @@ clean: clean-out
 	rm -rf build/
 
 .PHONY: all \
-		git-submodule-init \
 		build build-generator unittest \
 		generate-stage1 compile-stage1 $(tests) \
 		$(tests_patch) generate-stage2 compile-stage2 $(tests_stage2) \


### PR DESCRIPTION
Updating the submodule automatically makes development frustrating.
Users should initialize all submodules after cloning