### PR TITLE
clean-out should only clean OUTPUT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ $(tests_stage2):
 
 
 clean-out:
-	rm -rf out
+	rm -rf $(OUTPUT)
 
 clean: clean-out
 	go clean


### PR DESCRIPTION
This allow maintaining multiple output directories with different VLEN/MODE configurations