### PR TITLE
Remove fmax/fmin from fredusum

### DIFF
--- a/configs/vfredusum.vs.toml
+++ b/configs/vfredusum.vs.toml
@@ -12,9 +12,7 @@ fsew32 = [
     ["inf",                     "-inf"],
     ["quiet_nan",               "signaling_nan"],
     ["smallest_nonzero_float",  "largest_subnormal_float"],
-    ["smallest_normal_float",   "max_float"],
-    ["-smallest_nonzero_float", "-largest_subnormal_float"],
-    ["-smallest_normal_float",  "-max_float"]
+    ["-smallest_nonzero_float", "-largest_subnormal_float"]
 ]
 fsew64 = [
     ["2.5",                     "1.0"],
@@ -26,7 +24,5 @@ fsew64 = [
     ["inf",                     "-inf"],
     ["quiet_nan",               "signaling_nan"],
     ["smallest_nonzero_float",  "largest_subnormal_float"],
-    ["smallest_normal_float",   "max_float"],
-    ["-smallest_nonzero_float", "-largest_subnormal_float"],
-    ["-smallest_normal_float",  "-max_float"]
+    ["-smallest_nonzero_float", "-largest_subnormal_float"]
 ]


### PR DESCRIPTION
Implementations for which fredusum does not implement the same reduction order as fredosum will likely diverge from the reference model when fmax/fmin are present