### PR TITLE
Use https for riscv-test-env submodule instead of ssh auth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "env/riscv-test-env"]
 	path = env/riscv-test-env
-	url = git@github.com:riscv/riscv-test-env.git
+	url = https://github.com/riscv/riscv-test-env.git


### PR DESCRIPTION
I tried to use your tests on another CI platform which does not have ssh set up automatically.
Using https for the submodule would be nicer than forcing the user to have a github account and authenticate.