### PR TITLE
Fix test case for vmerge.vxm

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -666,6 +666,8 @@ tests = \
   vmerge.vvm-1 \
   vmerge.vxm-0 \
   vmerge.vxm-1 \
+  vmerge.vxm-2 \
+  vmerge.vxm-3 \
   vmfeq.vf-0 \
   vmfeq.vf-1 \
   vmfeq.vf-2 \

--- a/configs/vmerge.vxm.toml
+++ b/configs/vmerge.vxm.toml
@@ -1,5 +1,5 @@
-name = "vmerge.vvm"
-format = "vd,vs2,vs1,v0"
+name = "vmerge.vxm"
+format = "vd,vs2,rs1,v0"
 
 [tests]
 base = [


### PR DESCRIPTION
Noticed that this test was passing even though I had only implemented `vmerge.vvm`.