### PR TITLE
Fix lmul for vsext and vzext

### DIFF
--- a/generator/insn_vdvs2vmp3.go
+++ b/generator/insn_vdvs2vmp3.go
@@ -30,17 +30,9 @@ func (i *Insn) genCodeVdVs2VmP3(pos int) []string {
 		builder.WriteString(i.gLoadDataIntoRegisterGroup(0, c.LMUL1, c.SEW))
 
 		vs2EEW := c.SEW / SEW(f)
-		if vs2EEW < 8 {
-			res = append(res, "")
-			continue
-		}
 
-		vdEMUL := c.LMUL / LMUL(f)
-		if vdEMUL < 1/8 {
-			res = append(res, "")
-			continue
-		}
-		vdEMUL1 := LMUL(math.Max(float64(vdEMUL), 1))
+		vs2EMUL := c.LMUL / LMUL(f)
+		vs2EMUL1 := LMUL(math.Max(float64(vs2EMUL), 1))
 
 		vd := int(c.LMUL1)
 		vs2 := 2 * int(c.LMUL1)
@@ -48,8 +40,8 @@ func (i *Insn) genCodeVdVs2VmP3(pos int) []string {
 		builder.WriteString(i.gWriteRandomData(c.LMUL1))
 		builder.WriteString(i.gLoadDataIntoRegisterGroup(vd, c.LMUL1, c.SEW))
 
-		builder.WriteString(i.gWriteIntegerTestData(vdEMUL1, vs2EEW, 0))
-		builder.WriteString(i.gLoadDataIntoRegisterGroup(vs2, vdEMUL1, vs2EEW))
+		builder.WriteString(i.gWriteIntegerTestData(vs2EMUL1, vs2EEW, 0))
+		builder.WriteString(i.gLoadDataIntoRegisterGroup(vs2, vs2EMUL1, vs2EEW))
 
 		builder.WriteString("# -------------- TEST BEGIN --------------\n")
 		builder.WriteString(i.gVsetvli(c.Vl, c.SEW, c.LMUL))

--- a/generator/insn_vdvs2vmp3.go
+++ b/generator/insn_vdvs2vmp3.go
@@ -30,22 +30,26 @@ func (i *Insn) genCodeVdVs2VmP3(pos int) []string {
 		builder.WriteString(i.gLoadDataIntoRegisterGroup(0, c.LMUL1, c.SEW))
 
 		vs2EEW := c.SEW / SEW(f)
-		if vs2EEW > SEW(i.Option.XLEN) {
+		if vs2EEW < 8 {
 			res = append(res, "")
 			continue
 		}
 
-		vdEMUL := c.LMUL * LMUL(f)
+		vdEMUL := c.LMUL / LMUL(f)
+		if vdEMUL < 1/8 {
+			res = append(res, "")
+			continue
+		}
 		vdEMUL1 := LMUL(math.Max(float64(vdEMUL), 1))
 
-		vd := int(vdEMUL1)
-		vs2 := 2 * int(vdEMUL1)
+		vd := int(c.LMUL1)
+		vs2 := 2 * int(c.LMUL1)
 
 		builder.WriteString(i.gWriteRandomData(c.LMUL1))
-		builder.WriteString(i.gLoadDataIntoRegisterGroup(vd, vdEMUL1, c.SEW))
+		builder.WriteString(i.gLoadDataIntoRegisterGroup(vd, c.LMUL1, c.SEW))
 
-		builder.WriteString(i.gWriteIntegerTestData(c.LMUL1, vs2EEW, 0))
-		builder.WriteString(i.gLoadDataIntoRegisterGroup(vs2, c.LMUL1, vs2EEW))
+		builder.WriteString(i.gWriteIntegerTestData(vdEMUL1, vs2EEW, 0))
+		builder.WriteString(i.gLoadDataIntoRegisterGroup(vs2, vdEMUL1, vs2EEW))
 
 		builder.WriteString("# -------------- TEST BEGIN --------------\n")
 		builder.WriteString(i.gVsetvli(c.Vl, c.SEW, c.LMUL))
@@ -54,7 +58,7 @@ func (i *Insn) genCodeVdVs2VmP3(pos int) []string {
 		builder.WriteString("# -------------- TEST END   --------------\n")
 
 		builder.WriteString(i.gResultDataAddr())
-		builder.WriteString(i.gStoreRegisterGroupIntoResultData(vd, vdEMUL1, c.SEW))
+		builder.WriteString(i.gStoreRegisterGroupIntoResultData(vd, c.LMUL1, c.SEW))
 		builder.WriteString(i.gMagicInsn(vd))
 
 		res = append(res, builder.String())


### PR DESCRIPTION
The way I read the following lines in the spec is that for `vsext.vf4` or `vzext.vf4` source eew (=sew/4=16) and emul (=lmul/4=1/2) are smaller than the destination eew (=sew=64) and emul (=lmul=2).

> The EEW of the source is 1/2, 1/4, or 1/8 of SEW, while EMUL of the source is (EEW/SEW)*LMUL. The destination has EEW equal to SEW and EMUL equal to LMUL.

Fixed #26 