### PR TITLE
Fix vfwmul.vv

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -411,7 +411,6 @@ tests = \
   vfwmul.vf-0 \
   vfwmul.vf-1 \
   vfwmul.vv-0 \
-  vfwmul.vv-1 \
   vfwnmacc.vf-0 \
   vfwnmacc.vf-1 \
   vfwnmacc.vv-0 \

--- a/configs/vfwmul.vv.toml
+++ b/configs/vfwmul.vv.toml
@@ -1,4 +1,4 @@
-name = "vfmul.vv"
+name = "vfwmul.vv"
 format = "vd,vs2,vs1,vm"
 
 [tests]


### PR DESCRIPTION
I was just confused as to why for `XLEN=32` there was a testcase for `vfwmul.vv` generated.
Then I spotted this issue.